### PR TITLE
Change dto package names to match imports

### DIFF
--- a/backend/src/main/java/me/magicbudget/controller/BusinessController.java
+++ b/backend/src/main/java/me/magicbudget/controller/BusinessController.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import me.magicbudget.dto.incomingrequest.CreateBusinessRequest;
+import me.magicbudget.dto.incoming_request.CreateBusinessRequest;
 import me.magicbudget.model.Business;
 import me.magicbudget.model.User;
 import me.magicbudget.service.BusinessService;

--- a/backend/src/main/java/me/magicbudget/controller/CreditDebtController.java
+++ b/backend/src/main/java/me/magicbudget/controller/CreditDebtController.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import me.magicbudget.dto.incomingrequest.CreditDebtCreateRequest;
+import me.magicbudget.dto.incoming_request.CreditDebtCreateRequest;
 import me.magicbudget.model.Business;
 import me.magicbudget.model.CreditDebt;
 import me.magicbudget.service.BusinessService;

--- a/backend/src/main/java/me/magicbudget/controller/ExpenseController.java
+++ b/backend/src/main/java/me/magicbudget/controller/ExpenseController.java
@@ -1,7 +1,7 @@
 package me.magicbudget.controller;
 
-import me.magicbudget.dto.incomingrequest.ExpenseRequest;
-import me.magicbudget.dto.outgoingresponse.ExpenseResponse;
+import me.magicbudget.dto.incoming_request.ExpenseRequest;
+import me.magicbudget.dto.outgoing_response.ExpenseResponse;
 import me.magicbudget.service.ExpenseService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/me/magicbudget/controller/IncomeController.java
+++ b/backend/src/main/java/me/magicbudget/controller/IncomeController.java
@@ -1,7 +1,7 @@
 package me.magicbudget.controller;
 
-import me.magicbudget.dto.incomingrequest.IncomeRequest;
-import me.magicbudget.dto.outgoingresponse.IncomeResponse;
+import me.magicbudget.dto.incoming_request.IncomeRequest;
+import me.magicbudget.dto.outgoing_response.IncomeResponse;
 import me.magicbudget.repository.IncomeRepository;
 import me.magicbudget.repository.TransactionRepository;
 import me.magicbudget.service.IncomeService;

--- a/backend/src/main/java/me/magicbudget/controller/SavingGoalController.java
+++ b/backend/src/main/java/me/magicbudget/controller/SavingGoalController.java
@@ -3,7 +3,7 @@ package me.magicbudget.controller;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import me.magicbudget.dto.incomingrequest.SavingGoalCreateRequest;
+import me.magicbudget.dto.incoming_request.SavingGoalCreateRequest;
 import me.magicbudget.model.SavingGoal;
 import me.magicbudget.model.User;
 import me.magicbudget.service.SavingGoalService;

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/CreateBusinessRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/CreateBusinessRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 import jakarta.annotation.Nonnull;
 

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/CreditDebtCreateRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/CreditDebtCreateRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/ExpenseRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/ExpenseRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 import me.magicbudget.model.ExpenseCategory;
 import java.math.BigDecimal;

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/IncomeRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/IncomeRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 import me.magicbudget.model.IncomeType;
 import java.math.BigDecimal;

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/LoginUserRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/LoginUserRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 public record LoginUserRequest(String username, String password) {
 

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/RegistrationAndAuthRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/RegistrationAndAuthRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 public record RegistrationAndAuthRequest(String username,
                                          String password,

--- a/backend/src/main/java/me/magicbudget/dto/incoming_request/SavingGoalCreateRequest.java
+++ b/backend/src/main/java/me/magicbudget/dto/incoming_request/SavingGoalCreateRequest.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.incomingrequest;
+package me.magicbudget.dto.incoming_request;
 
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;

--- a/backend/src/main/java/me/magicbudget/dto/outgoing_response/ExpenseResponse.java
+++ b/backend/src/main/java/me/magicbudget/dto/outgoing_response/ExpenseResponse.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.outgoingresponse;
+package me.magicbudget.dto.outgoing_response;
 
 import me.magicbudget.model.ExpenseCategory;
 import java.math.BigDecimal;

--- a/backend/src/main/java/me/magicbudget/dto/outgoing_response/IncomeResponse.java
+++ b/backend/src/main/java/me/magicbudget/dto/outgoing_response/IncomeResponse.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.outgoingresponse;
+package me.magicbudget.dto.outgoing_response;
 
 import me.magicbudget.model.IncomeType;
 import java.math.BigDecimal;

--- a/backend/src/main/java/me/magicbudget/dto/outgoing_response/LoginUserResponse.java
+++ b/backend/src/main/java/me/magicbudget/dto/outgoing_response/LoginUserResponse.java
@@ -1,4 +1,4 @@
-package me.magicbudget.dto.outgoingresponse;
+package me.magicbudget.dto.outgoing_response;
 
 import java.util.UUID;
 

--- a/backend/src/main/java/me/magicbudget/security/service/RegistrationAndAuthService.java
+++ b/backend/src/main/java/me/magicbudget/security/service/RegistrationAndAuthService.java
@@ -1,7 +1,7 @@
 package me.magicbudget.security.service;
 
-import me.magicbudget.dto.incomingrequest.LoginUserRequest;
-import me.magicbudget.dto.incomingrequest.RegistrationAndAuthRequest;
+import me.magicbudget.dto.incoming_request.LoginUserRequest;
+import me.magicbudget.dto.incoming_request.RegistrationAndAuthRequest;
 import me.magicbudget.model.User;
 import me.magicbudget.model.UserInformation;
 import me.magicbudget.repository.UserInformationRepository;

--- a/backend/src/main/java/me/magicbudget/service/ExpenseService.java
+++ b/backend/src/main/java/me/magicbudget/service/ExpenseService.java
@@ -1,7 +1,7 @@
 package me.magicbudget.service;
 
-import me.magicbudget.dto.incomingrequest.ExpenseRequest;
-import me.magicbudget.dto.outgoingresponse.ExpenseResponse;
+import me.magicbudget.dto.incoming_request.ExpenseRequest;
+import me.magicbudget.dto.outgoing_response.ExpenseResponse;
 import me.magicbudget.model.Expense;
 import me.magicbudget.model.ExpenseCategory;
 import me.magicbudget.model.Transaction;

--- a/backend/src/main/java/me/magicbudget/service/IncomeService.java
+++ b/backend/src/main/java/me/magicbudget/service/IncomeService.java
@@ -1,7 +1,7 @@
 package me.magicbudget.service;
 
-import me.magicbudget.dto.incomingrequest.IncomeRequest;
-import me.magicbudget.dto.outgoingresponse.IncomeResponse;
+import me.magicbudget.dto.incoming_request.IncomeRequest;
+import me.magicbudget.dto.outgoing_response.IncomeResponse;
 import me.magicbudget.model.Income;
 import me.magicbudget.model.Transaction;
 import me.magicbudget.model.TransactionType;


### PR DESCRIPTION
When I pulled the latest main, the package names didn't match the import statements. Fixed that by changing the package names `incomingrequest` -> `incoming-request` and `outgoingresponse`->`outgoing-response`